### PR TITLE
fix 🐛 (nixosModules/rpcuIaaSCP): disable libvirtd virtualization in osconfig

### DIFF
--- a/nixosModules/rpcuIaaSCP/osconfig.nix
+++ b/nixosModules/rpcuIaaSCP/osconfig.nix
@@ -105,12 +105,12 @@
       fsType = "ext4";
     };
   };
-  virtualisation.libvirtd.enable = true;
-  # Enable KVM (recommended)
-  virtualisation.libvirtd.qemu = {
-    package = pkgs.qemu_kvm;
-    runAsRoot = true;
-  };
+  # virtualisation.libvirtd.enable = true;
+  # # Enable KVM (recommended)
+  # virtualisation.libvirtd.qemu = {
+  #   package = pkgs.qemu_kvm;
+  #   runAsRoot = true;
+  # };
   users = {
     groups = {
       operator.gid = 2500000;


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
