### PR TITLE
fix 🐛 (rpcuIaaSCP): remove v prefix from kubeletVersion for consistency with kubeadmVersion

### DIFF
--- a/nixosModules/rpcuIaaSCP/vars.nix
+++ b/nixosModules/rpcuIaaSCP/vars.nix
@@ -3,7 +3,7 @@
 let
   # Kubernetes versioning
   kubeadmVersion = "1.36.1";
-  kubeletVersion = "v1.36.1";
+  kubeletVersion = "1.36.1";
   kubevipVersion = "v1.0.4";
 
   # Network configuration


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
